### PR TITLE
fix(servicio): agregar manejo transaccional y establecer estado inicial de tarea como no completada

### DIFF
--- a/src/main/java/cl/crisjonhson/PomodoroFocusTasks/model/Task.java
+++ b/src/main/java/cl/crisjonhson/PomodoroFocusTasks/model/Task.java
@@ -16,7 +16,7 @@ public class Task {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     
-    @NotBlank
+    @NotBlank(message = "no debe estar vacío") 
     private String title;
     
     private String description;

--- a/src/main/java/cl/crisjonhson/PomodoroFocusTasks/services/TaskService.java
+++ b/src/main/java/cl/crisjonhson/PomodoroFocusTasks/services/TaskService.java
@@ -3,6 +3,8 @@ package cl.crisjonhson.PomodoroFocusTasks.services;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import cl.crisjonhson.PomodoroFocusTasks.model.Task;
 import cl.crisjonhson.PomodoroFocusTasks.repository.TaskRepository;
 
@@ -15,7 +17,10 @@ public class TaskService {
         return taskRepository.findAll();
     }
 
+    @Transactional
     public Task saveTask(Task task) {
+        System.out.println("Guardando tarea: " + task); // Debug
+        task.setCompleted(false); // Asegúrate de que la tarea se inicie como no completada
         return taskRepository.save(task);
     }
 


### PR DESCRIPTION
- Se añadió la anotación "Transactional" en el método saveTask para asegurar la integridad de la transacción.
- Se incluyó task.setCompleted(false) para inicializar las nuevas tareas como no completadas, garantizando que el estado de la tarea sea consistente al momento de su creación.
